### PR TITLE
Hotfix docker build issue caused by mixing new setuptools and old pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,11 +50,11 @@ RUN set -ex \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     # && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
     && pip install pytz==2015.7 \
-    && pip install cryptography \
-    && pip install pyOpenSSL \
-    && pip install ndg-httpsclient \
-    && pip install pyasn1 \
-    && pip install protobuf \
+    && pip install cryptography==1.7.2 \
+    && pip install pyOpenSSL==16.2.0 \
+    && pip install ndg-httpsclient==0.4.2 \
+    && pip install pyasn1==0.1.9 \
+    && pip install protobuf==3.2.0 \
     && pip install pydash==3.4.3 \
     && pip install pymongo==3.2.2 \
     && pip install stringcase==1.0.6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN set -ex \
     && locale-gen \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     # && useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow \
+    && python -m pip install -U pip \
     && pip install pytz==2015.7 \
     && pip install cryptography==1.7.2 \
     && pip install pyOpenSSL==16.2.0 \


### PR DESCRIPTION
See expanded commit messages for more info.  This should make builds pass on CircleCI again.

Long story short pip coming from apt's `python-pip` package installs a ~3 year old version of pip.  This forces pip to update itself to the very latest release.